### PR TITLE
Add mixed encoder behaviors

### DIFF
--- a/config/meteorite40.keymap
+++ b/config/meteorite40.keymap
@@ -70,6 +70,22 @@
             tap-ms = <25>;
             display-name = "Encoder Key Press";
         };
+
+        enc_msc_kp: encoder_mouse_scroll_key_press {
+            compatible = "zmk,behavior-sensor-rotate-var";
+            #sensor-binding-cells = <2>;
+            bindings = <&msc>, <&kp>;
+            tap-ms = <25>;
+            display-name = "Encoder Mouse Scroll / Key Press";
+        };
+
+        enc_kp_msc: encoder_key_press_mouse_scroll {
+            compatible = "zmk,behavior-sensor-rotate-var";
+            #sensor-binding-cells = <2>;
+            bindings = <&kp>, <&msc>;
+            tap-ms = <25>;
+            display-name = "Encoder Key Press / Mouse Scroll";
+        };
     };
 
     combos {


### PR DESCRIPTION
## Summary
- Add mixed encoder sensor behaviors so one encoder direction can use mouse scroll while the other uses key press.
- Keep existing homogeneous `Encoder Mouse Scroll` and `Encoder Key Press` behaviors for existing keymap lines.

## Validation
- `git diff --check`
- Firmware build not run locally; this PR is draft pending CI/device confirmation.

## Manual check / Not verified
- Physical encoder CW/CCW mixed behavior Apply/Save flow is not verified yet.