### PR TITLE
fix(config): add mixed low encoder behaviors

### DIFF
--- a/config/meteorite40_low.keymap
+++ b/config/meteorite40_low.keymap
@@ -70,6 +70,22 @@
             tap-ms = <25>;
             display-name = "Encoder Key Press";
         };
+
+        enc_msc_kp: encoder_mouse_scroll_key_press {
+            compatible = "zmk,behavior-sensor-rotate-var";
+            #sensor-binding-cells = <2>;
+            bindings = <&msc>, <&kp>;
+            tap-ms = <25>;
+            display-name = "Encoder Mouse Scroll / Key Press";
+        };
+
+        enc_kp_msc: encoder_key_press_mouse_scroll {
+            compatible = "zmk,behavior-sensor-rotate-var";
+            #sensor-binding-cells = <2>;
+            bindings = <&kp>, <&msc>;
+            tap-ms = <25>;
+            display-name = "Encoder Key Press / Mouse Scroll";
+        };
     };
 
     combos {


### PR DESCRIPTION
## Summary
- Add `Encoder Mouse Scroll / Key Press` and `Encoder Key Press / Mouse Scroll` behavior definitions to `meteorite40_low.keymap`.
- Align the low profile with the normal Meteorite40 encoder capabilities so a scroll-assigned encoder direction can switch to Key Press in the editor.

## Validation
- `git diff --check`
- GitHub Actions firmware build will validate the full user config matrix after PR creation.

## Manual check / Not verified
- Not verified on physical hardware.
- Low firmware was not locally built; merge is gated on GitHub Actions.