### PR TITLE
fix(config): simplify encoder defaults

### DIFF
--- a/config/meteorite40.keymap
+++ b/config/meteorite40.keymap
@@ -71,21 +71,6 @@
             display-name = "Encoder Key Press";
         };
 
-        enc_msc_kp: encoder_mouse_scroll_key_press {
-            compatible = "zmk,behavior-sensor-rotate-var";
-            #sensor-binding-cells = <2>;
-            bindings = <&msc>, <&kp>;
-            tap-ms = <25>;
-            display-name = "Encoder Mouse Scroll / Key Press";
-        };
-
-        enc_kp_msc: encoder_key_press_mouse_scroll {
-            compatible = "zmk,behavior-sensor-rotate-var";
-            #sensor-binding-cells = <2>;
-            bindings = <&kp>, <&msc>;
-            tap-ms = <25>;
-            display-name = "Encoder Key Press / Mouse Scroll";
-        };
     };
 
     combos {
@@ -154,8 +139,8 @@
             >;
 
             sensor-bindings =
-                <&enc_msc SCRL_RIGHT SCRL_LEFT>,
-                <&enc_msc SCRL_UP SCRL_DOWN>;
+                <&enc_kp C_VOL_DN C_VOL_UP>,
+                <&enc_kp C_VOL_DN C_VOL_UP>;
         };
 
         layer_1 {
@@ -168,8 +153,8 @@
             >;
 
             sensor-bindings =
-                <&enc_msc SCRL_UP SCRL_DOWN>,
-                <&enc_msc SCRL_RIGHT SCRL_LEFT>;
+                <&enc_kp C_VOL_DN C_VOL_UP>,
+                <&enc_kp C_VOL_DN C_VOL_UP>;
         };
 
         layer_2 {
@@ -182,7 +167,7 @@
             >;
 
             sensor-bindings =
-                <&enc_kp LC(MINUS) LC(EQUAL)>,
+                <&enc_kp C_VOL_DN C_VOL_UP>,
                 <&enc_kp C_VOL_DN C_VOL_UP>;
 
         };
@@ -197,7 +182,7 @@
             >;
 
             sensor-bindings =
-                <&enc_kp LC(MINUS) LC(EQUAL)>,
+                <&enc_kp C_VOL_DN C_VOL_UP>,
                 <&enc_kp C_VOL_DN C_VOL_UP>;
 
         };
@@ -211,7 +196,7 @@
 			>;
 
             sensor-bindings =
-                <&enc_kp LC(MINUS) LC(EQUAL)>,
+                <&enc_kp C_VOL_DN C_VOL_UP>,
                 <&enc_kp C_VOL_DN C_VOL_UP>;
         };
     };

--- a/config/meteorite40_low.keymap
+++ b/config/meteorite40_low.keymap
@@ -71,21 +71,6 @@
             display-name = "Encoder Key Press";
         };
 
-        enc_msc_kp: encoder_mouse_scroll_key_press {
-            compatible = "zmk,behavior-sensor-rotate-var";
-            #sensor-binding-cells = <2>;
-            bindings = <&msc>, <&kp>;
-            tap-ms = <25>;
-            display-name = "Encoder Mouse Scroll / Key Press";
-        };
-
-        enc_kp_msc: encoder_key_press_mouse_scroll {
-            compatible = "zmk,behavior-sensor-rotate-var";
-            #sensor-binding-cells = <2>;
-            bindings = <&kp>, <&msc>;
-            tap-ms = <25>;
-            display-name = "Encoder Key Press / Mouse Scroll";
-        };
     };
 
     combos {
@@ -153,8 +138,8 @@
                                     &kp LWIN  &mt LCTRL TAB  &mt LSHIFT SPACE  &lt 1 SPACE  &lt 2 ENTER  &lt 2 BSPC  &lt 3 DEL  &kp RALT
             >;
             sensor-bindings =
-                <&enc_msc SCRL_RIGHT SCRL_LEFT>,
-                <&enc_msc SCRL_UP SCRL_DOWN>;
+                <&enc_kp C_VOL_DN C_VOL_UP>,
+                <&enc_kp C_VOL_DN C_VOL_UP>;
         };
 
         layer_1 {
@@ -166,8 +151,8 @@
                                      &trans     &trans    &trans    &trans    &trans     &kp DEL    &trans     &trans
             >;
             sensor-bindings =
-                <&enc_msc SCRL_UP SCRL_DOWN>,
-                <&enc_msc SCRL_RIGHT SCRL_LEFT>;
+                <&enc_kp C_VOL_DN C_VOL_UP>,
+                <&enc_kp C_VOL_DN C_VOL_UP>;
         };
 
         layer_2 {
@@ -179,7 +164,7 @@
                                         &trans           &trans     &trans     &trans    &trans        &trans  &trans    &trans
             >;
             sensor-bindings =
-                <&enc_kp LC(MINUS) LC(EQUAL)>,
+                <&enc_kp C_VOL_DN C_VOL_UP>,
                 <&enc_kp C_VOL_DN C_VOL_UP>;
         };
 
@@ -192,7 +177,7 @@
                                 &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans
             >;
             sensor-bindings =
-                <&enc_kp LC(MINUS) LC(EQUAL)>,
+                <&enc_kp C_VOL_DN C_VOL_UP>,
                 <&enc_kp C_VOL_DN C_VOL_UP>;
         };
 
@@ -205,7 +190,7 @@
 												                    &trans       &trans  &trans  &trans  &trans  &trans    &trans        &trans
 			>;
             sensor-bindings =
-                <&enc_kp LC(MINUS) LC(EQUAL)>,
+                <&enc_kp C_VOL_DN C_VOL_UP>,
                 <&enc_kp C_VOL_DN C_VOL_UP>;
         };
     };


### PR DESCRIPTION
## Summary
- Set all Meteorite40 and Meteorite40 Low layer encoder defaults to volume down/up.
- Remove unused mixed mouse-scroll/key-press encoder wrapper behaviors.
- Keep `enc_msc` and `enc_kp`; `enc_kp` remains the initial volume default seed.

## Validation
- `rg -n "enc_msc_kp|enc_kp_msc" config boards Kconfig build.yaml -S` returned no references.
- `rg -n "sensor-bindings =|<&enc_" config/meteorite40.keymap config/meteorite40_low.keymap` confirmed all layer sensor bindings use `C_VOL_DN` / `C_VOL_UP`.
- `git diff --check`

## Manual check / Not verified
- Local firmware build was not run because `west list` reports this checkout is not inside a west workspace.
- Physical device behavior was not manually verified.
