### PR TITLE
feat: add persisted system settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/boards/shields/common/meteorite40.dtsi
+++ b/boards/shields/common/meteorite40.dtsi
@@ -207,8 +207,6 @@
     custom_config_defaults: custom_config_defaults {
         compatible = "zmk,custom-config-defaults";
         os-mode = <OS_MODE_DEFAULT>;
-        mod-tap-tapping-term-ms = <200>;
-        layer-tap-tapping-term-ms = <150>;
         idle-timeout-s = <120>;
         idle-sleep-timeout-s = <900>;
     };

--- a/boards/shields/common/meteorite40.dtsi
+++ b/boards/shields/common/meteorite40.dtsi
@@ -207,6 +207,10 @@
     custom_config_defaults: custom_config_defaults {
         compatible = "zmk,custom-config-defaults";
         os-mode = <OS_MODE_DEFAULT>;
+        mod-tap-tapping-term-ms = <200>;
+        layer-tap-tapping-term-ms = <150>;
+        idle-timeout-s = <120>;
+        idle-sleep-timeout-s = <900>;
     };
 
     behaviors {

--- a/config/meteorite40.keymap
+++ b/config/meteorite40.keymap
@@ -20,6 +20,7 @@
     tapping-term-ms = <200>;
     meteorite-tapping-term-source = "mod-tap";
     quick-tap-ms = <150>; // change 200 to 150
+    require-prior-idle-ms = <(-1)>;
 };
 
 &lt {
@@ -27,6 +28,7 @@
     tapping-term-ms = <150>; // change 200 to 150
     meteorite-tapping-term-source = "layer-tap";
     quick-tap-ms = <150>; // change 200 to 150
+    require-prior-idle-ms = <(-1)>;
 };
 
 / { 

--- a/config/meteorite40.keymap
+++ b/config/meteorite40.keymap
@@ -18,12 +18,14 @@
 &mt { 
     flavor = "tap-preferred"; // change hold to tap
     tapping-term-ms = <200>;
+    meteorite-tapping-term-source = "mod-tap";
     quick-tap-ms = <150>; // change 200 to 150
 };
 
 &lt {
     flavor = "tap-preferred";
     tapping-term-ms = <150>; // change 200 to 150
+    meteorite-tapping-term-source = "layer-tap";
     quick-tap-ms = <150>; // change 200 to 150
 };
 
@@ -33,7 +35,8 @@
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "tap-preferred";
-            tapping-term-ms = <150>;
+            tapping-term-ms = <200>;
+            meteorite-tapping-term-source = "mod-tap";
             bindings = <&mck>, <&kp>;
             display-name = "meteorite OS-Switch-mod-tap";
         };
@@ -42,7 +45,8 @@
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "tap-preferred";
-            tapping-term-ms = <150>;
+            tapping-term-ms = <200>;
+            meteorite-tapping-term-source = "mod-tap";
             bindings = <&mck>, <&alt_cmd_tab>;
             display-name = "meteorite OS-Switch-mod-tap (smart toggle)";
         };

--- a/config/meteorite40_low.keymap
+++ b/config/meteorite40_low.keymap
@@ -20,6 +20,7 @@
     tapping-term-ms = <200>;
     meteorite-tapping-term-source = "mod-tap";
     quick-tap-ms = <150>; // change 200 to 150
+    require-prior-idle-ms = <(-1)>;
 };
 
 &lt {
@@ -27,6 +28,7 @@
     tapping-term-ms = <150>; // change 200 to 150
     meteorite-tapping-term-source = "layer-tap";
     quick-tap-ms = <150>; // change 200 to 150
+    require-prior-idle-ms = <(-1)>;
 };
 
 / {

--- a/config/meteorite40_low.keymap
+++ b/config/meteorite40_low.keymap
@@ -18,12 +18,14 @@
 &mt { 
     flavor = "tap-preferred"; // change hold to tap
     tapping-term-ms = <200>;
+    meteorite-tapping-term-source = "mod-tap";
     quick-tap-ms = <150>; // change 200 to 150
 };
 
 &lt {
     flavor = "tap-preferred";
     tapping-term-ms = <150>; // change 200 to 150
+    meteorite-tapping-term-source = "layer-tap";
     quick-tap-ms = <150>; // change 200 to 150
 };
 
@@ -33,7 +35,8 @@
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "tap-preferred";
-            tapping-term-ms = <150>;
+            tapping-term-ms = <200>;
+            meteorite-tapping-term-source = "mod-tap";
             bindings = <&mck>, <&kp>;
             display-name = "meteorite OS-Switch-mod-tap";
         };
@@ -42,7 +45,8 @@
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "tap-preferred";
-            tapping-term-ms = <150>;
+            tapping-term-ms = <200>;
+            meteorite-tapping-term-source = "mod-tap";
             bindings = <&mck>, <&alt_cmd_tab>;
             display-name = "meteorite OS-Switch-mod-tap (smart toggle)";
         };

--- a/config/west-local.yml
+++ b/config/west-local.yml
@@ -1,0 +1,13 @@
+# ローカルビルド専用 manifest。CI は config/west.yml を使い、このファイルを参照しない。
+# 用途・手順は firmware/build-workspace/LOCAL_BUILD.md を参照。
+# zmk-west-commands は firmware/zmk-west-commands/ のローカル checkout が正本
+# (url は自己参照。west update してもリモートへ出ない。上流取り込みは git fetch origin を手動実行)。
+manifest:
+  projects:
+    - name: zmk-west-commands
+      url: file:///C:/Users/iwkno/Documents/keyboard/meteorite40_ZMK/firmware/zmk-west-commands
+      revision: main
+      west-commands: scripts/west-commands.yml
+  self:
+    path: config
+    import: west.yml

--- a/config/west.yml
+++ b/config/west.yml
@@ -7,13 +7,13 @@ manifest:
   projects:
     - name: zmk
       remote: iwk7273
-      revision: feat/meteorite-custom-config-rpc
+      revision: feat/persist-system-timing
       import: app/west.yml
     - name: zmk-pmw3610-driver
       remote: iwk7273
       revision: main
     - name: zmk-feature-meteorite-config
       remote: iwk7273
-      revision: 03664e9abab245a41bec39dc79c33eff3282c92b
+      revision: feat/persist-system-timing
   self:
     path: config

--- a/config/west.yml
+++ b/config/west.yml
@@ -7,13 +7,13 @@ manifest:
   projects:
     - name: zmk
       remote: iwk7273
-      revision: feat/persist-system-timing
+      revision: 9e0c5a8206f2bfafc53005aa898436bb96d41986
       import: app/west.yml
     - name: zmk-pmw3610-driver
       remote: iwk7273
       revision: main
     - name: zmk-feature-meteorite-config
       remote: iwk7273
-      revision: feat/persist-system-timing
+      revision: 3a477d90bb117841df9b2bea2688339ebe866a51
   self:
     path: config

--- a/new_release_notes.md
+++ b/new_release_notes.md
@@ -1,0 +1,25 @@
+﻿## 🚀 新機能: Ball Profiles の統合
+
+Meteorite40 のトラックボール操作をさらに細かくカスタマイズできる「Ball Profiles」機能を統合しました！
+Meteorite Studio 上で「Ball profiles」タブから、トラックボールの挙動を直感的に設定可能です。
+
+![Ball Profiles 設定画面](https://github.com/iwk7273/zmk-config-meteorite40/releases/download/v4.3.0/ball_profiles_highlight.png)
+
+### 主な設定項目
+1. **ACTION SENSITIVITY (感度調整)**
+   ボールを転がした時の感度（重さ）をスライダーで直感的に調整できます。
+2. **LAYER PROFILES (レイヤーごとの動作)**
+   各レイヤー（SYMBOLS, NUM / ARROW など）ごとにボールの動作 (Scroll, Browserなど) を個別に割り当てられます。
+3. **USER 1 BINDINGS (カスタム割り当て)**
+   "User 1" プロファイル選択時は、上下左右の各方向に対して好きなキー操作を自由に割り当てることが可能です。
+
+---
+### ✨ その他の改善とアップデート
+- **Studio への Bluetooth 接続対応**
+  これまで USB 接続が必要だった Studio アプリへの接続が、**Bluetooth 経由でも可能になりました！** ケーブルを繋ぐことなく、ワイヤレスのままで快適にキーマップや設定の変更が行えます。
+- **ファームウェア・アップデート通知機能**
+  Studio アプリ接続時にキーボードのファームウェアバージョンを確認し、新しいバージョンがリリースされている場合は通知を受け取れるようになりました。
+
+### 📥 アップデート方法
+下部の **Assets** からお使いのモデルに合った .uf2 ファイルをダウンロードし、キーボードに書き込んでアップデートを行ってください。
+*(Commit 727ff7e)*


### PR DESCRIPTION
## Summary
- source Mod-tap and Layer-tap defaults from the normal and Low keymaps
- enable persistent Hold-tap and Power configuration
- pin the released ZMK and custom-config module revisions by immutable SHA
- retain the explicitly tracked local build manifest and workspace support files

## Validation
- build-workspace/build.ps1 completed both targets
- meteorite40.uf2: 562176 bytes
- meteorite40_low.uf2: 556544 bytes
- the user completed physical-device Mod-tap, Layer-tap, Power, persistence, reset, reboot, and encoder checks

## Manual check / Not verified
- GitHub Actions will rebuild using config/west.yml immutable pins before merge
- release target is v4.4.0