### PR TITLE
feat(scroll): use adaptive scaling v2

### DIFF
--- a/boards/shields/common/meteorite40.dtsi
+++ b/boards/shields/common/meteorite40.dtsi
@@ -25,15 +25,13 @@
 #define INVERT_Y 0              // Y軸のスクロールの反転
 
 #define SCALING_MODE 1          // 0: 無効, 1: 有効
-#define SCROLL_SCALING_MODE 0   // 0: 無効, 1: 有効
+#define SCROLL_SCALING_MODE 0   // 0: Linear, 1: Adaptive
 #define OS_MODE_DEFAULT 0       // 0: Win, 1: Mac
 #define MAX_OUTPUT 300          // 出力の最大絶対値 |y|。既定 127
 #define HALF_INPUT 50           // r=|x|/xs の xs（counts）。既定 50
 #define EXPONENT_TENTHS 12      // 指数 p を 0.1 分解能で指定（p*10、例: 15 は p=1.5）。既定 10（p=1.0）
 
-#define SCROLL_MAX_OUTPUT 300
-#define SCROLL_HALF_INPUT 55
-#define SCROLL_EXPONENT_TENTHS 6  // p = 0.6
+#define SCROLL_DEFAULT_DT_MS 12 // reset直後の物理速度計算に使う既定report間隔
 
 #define POLL_PERIOD_MS 15       // キースキャンのポーリング周期（ms）
 #define DEBOUNCE_MS 10           // デバウンス時間 (ms)
@@ -146,18 +144,9 @@
     };
     */
 
-    to_wheel: to_wheel {
-        compatible = "zmk,input-processor-code-mapper";
-        #input-processor-cells = <0>;
-        type = <INPUT_EV_REL>;
-        map = <INPUT_REL_X INPUT_REL_HWHEEL>,
-              <INPUT_REL_Y INPUT_REL_WHEEL>;
-    };
-
     motion_scaler: motion_scaler {
         compatible = "zmk,input-processor-meteorite-motion-scaler";
         #input-processor-cells = <0>;
-        custom-config-scaling = <0>;
         scaling-mode = <SCALING_MODE>;
         max-output = <MAX_OUTPUT>;
         half-input = <HALF_INPUT>;
@@ -165,29 +154,21 @@
         track-remainders;
     };
 
-    scroll_motion_scaler: motion_scaler_scroll {
-        compatible = "zmk,input-processor-meteorite-motion-scaler";
+    scroll_transform: scroll_transform {
+        compatible = "zmk,input-processor-meteorite-scroll-transform";
         #input-processor-cells = <0>;
-        custom-config-scaling = <1>;
+        threshold = <CLIPPER_THRESHOLD>;
+        invert-x = <INVERT_X>;
+        invert-y = <INVERT_Y>;
         scaling-mode = <SCROLL_SCALING_MODE>;
-        max-output = <SCROLL_MAX_OUTPUT>;
-        half-input = <SCROLL_HALF_INPUT>;
-        exponent-tenths = <SCROLL_EXPONENT_TENTHS>;
-        //track-remainders;
+        cpi = <DEFAULT_CPI>;
+        default-dt-ms = <SCROLL_DEFAULT_DT_MS>;
     };
 
     sensor_rotation: sensor_rotation {
         compatible = "zmk,input-processor-meteorite-sensor-rotation";
         #input-processor-cells = <0>;
         rotation-angle = <ROTATION_ANGLE>;
-    };
-
-    xy_clipper: xy_clipper {
-        compatible = "zmk,input-processor-meteorite-xy-clipper";
-        #input-processor-cells = <0>;
-        threshold = <CLIPPER_THRESHOLD>;
-        invert-x = <INVERT_X>;
-        invert-y = <INVERT_Y>;
     };
 
     /*
@@ -224,10 +205,8 @@
     ball_profile_router: ball_profile_router {
         compatible = "zmk,input-processor-meteorite-ball-profile";
         #input-processor-cells = <0>;
-        /* SCROLL profile のサブチェーン（現挙動を踏襲） */
-        input-processors = <&xy_clipper>,
-                           <&scroll_motion_scaler>,
-                           <&to_wheel>;
+        /* raw motionへgainを適用してからstep化するScroll Scaling v2 */
+        input-processors = <&scroll_transform>;
         /* 固定 Profile の 12 binding（profile-major / 方向 LEFT,RIGHT,UP,DOWN）。
          * &ball_mosk <Win> <Mac>（0 = そのOSで no-op）、OS非依存は &kp。
          * ズームは consumer の C_AC_ZOOM_IN/OUT だとブラウザ/OS が反応しないため、

--- a/config/west.yml
+++ b/config/west.yml
@@ -14,6 +14,6 @@ manifest:
       revision: main
     - name: zmk-feature-meteorite-config
       remote: iwk7273
-      revision: 3a477d90bb117841df9b2bea2688339ebe866a51
+      revision: 02e3cffc3f7785af3f699ed8e6171a9fb8ccd5a2
   self:
     path: config


### PR DESCRIPTION
## Summary
- Replace the legacy clipper → motion scaler → code mapper scroll chain with the V2 scroll transform.
- Keep `SCROLL_SCALING_MODE` compatible as `0: Linear` and `1: Adaptive`.
- Pin `zmk-feature-meteorite-config` to `02e3cffc3f7785af3f699ed8e6171a9fb8ccd5a2`.

## Validation
- `build-workspace\build.ps1` — normal, debug, low, and low-debug builds succeeded.
- Confirmed all four ELFs expose `Scroll scaling`, with no `Scroll response` string.
- `git diff --check`

## Manual check / Not verified
- The generated UF2 has not been flashed; connected-device UI and physical scroll feel are not verified.