### PR TITLE
ci(release): harden firmware release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,12 @@
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: firmware-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,6 +38,15 @@ jobs:
         with:
           name: firmware
           path: dist
+      - name: Normalize release asset names
+        shell: bash
+        run: |
+          mv dist/meteorite40-xiao_ble__zmk-zmk.uf2 dist/meteorite40.uf2
+          mv dist/meteorite40_low-xiao_ble__zmk-zmk.uf2 dist/meteorite40_low.uf2
+          sha256sum dist/meteorite40.uf2 dist/meteorite40_low.uf2
       - env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ needs.release-please.outputs.tag_name }}" dist/*.uf2 --repo "${{ github.repository }}"
+        run: >-
+          gh release upload "${{ needs.release-please.outputs.tag_name }}"
+          dist/meteorite40.uf2 dist/meteorite40_low.uf2
+          --repo "${{ github.repository }}"

--- a/.github/workflows/validate-release-pr.yml
+++ b/.github/workflows/validate-release-pr.yml
@@ -1,0 +1,28 @@
+name: validate-release-pr
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  release-please-body:
+    if: startsWith(github.head_ref, 'release-please--branches--')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify Release Please metadata
+        shell: bash
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if [[ "$PR_BODY" != ':robot: I have created a release *beep* *boop*'* ]]; then
+            echo '::error::Release Please PR body header is missing. Restore the generated PR body instead of replacing it.'
+            exit 1
+          fi
+
+          if [[ "$PR_BODY" != *'This PR was generated with [Release Please]'* ]]; then
+            echo '::error::Release Please PR body footer is missing. Restore the generated PR body instead of replacing it.'
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- avoid duplicate firmware builds for both a feature-branch push and its pull request
- reject Release Please pull requests whose generated body metadata was replaced
- normalize CI firmware artifacts and upload only the two public UF2 names

## Root cause

The build workflow listened to every push and every pull request, Release Please depended on its generated PR body remaining parseable, and automatic asset upload used a wildcard without normalizing reusable-workflow artifact names.

## Validation

- parsed all workflow YAML files successfully
- verified the generated Release Please body passes the new guard
- verified the overwritten v4.5.0 body fails the new guard
- `git diff --check`